### PR TITLE
fix(ci): Fix permissions of `GITHUB_TOKEN` in order to deploy GitHub pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
 
+    permissions:
+      pages: write
+      id-token: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This is just a small follow-up PR for #30 

I forgot to set the proper permissions for the GitHub actions workflow which deploys the documentation to GitHub pages.